### PR TITLE
Add FilebasedUserService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.univocity</groupId>
+			<artifactId>univocity-parsers</artifactId>
+			<version>2.9.1</version>
+		</dependency>
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-registry-prometheus</artifactId>
 			<scope>runtime</scope>

--- a/src/main/java/no/ssb/dapla/team/users/FilebasedUserService.java
+++ b/src/main/java/no/ssb/dapla/team/users/FilebasedUserService.java
@@ -1,0 +1,60 @@
+package no.ssb.dapla.team.users;
+
+import com.univocity.parsers.annotations.Parsed;
+import com.univocity.parsers.common.processor.BeanListProcessor;
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.util.List;
+
+/**
+ * UserService that retrieves data from an offline user database (csv-file). The following outlines how the user file
+ * can be created: https://github.com/statisticsnorway/dapla-start-toolkit#update-ssb-users-list-served-by-dapla-start-api
+ */
+@Service
+public class FilebasedUserService {
+
+    private final String usersFilePath;
+
+    public FilebasedUserService(@NonNull @Value("${ad.users.exportfile}") String usersFilePath) {
+        this.usersFilePath = usersFilePath;
+    }
+
+    public List<User> fetchAllUsers() {
+        try (Reader inputReader = new InputStreamReader(Files.newInputStream(new File(usersFilePath).toPath()), "UTF-8")) {
+            BeanListProcessor<AdUser> rowProcessor = new BeanListProcessor<>(AdUser.class);
+            CsvParserSettings settings = new CsvParserSettings();
+            settings.setHeaderExtractionEnabled(true);
+            settings.setProcessor(rowProcessor);
+            CsvParser parser = new CsvParser(settings);
+            parser.parse(inputReader);
+            return rowProcessor.getBeans().stream()
+                    .map(adUser -> User.builder()
+                            .name(adUser.getDisplayName())
+                            .email(adUser.getMail())
+                            .emailShort(adUser.getUserPrincipalName())
+                            .build()).toList();
+
+        } catch (IOException e) {
+            throw new UserServiceException("Failed to read ssb users from file " + usersFilePath, e);
+        }
+    }
+
+    @Data
+    public static class AdUser {
+        @Parsed
+        private String userPrincipalName;
+        @Parsed
+        private String displayName;
+        @Parsed
+        private String mail;
+    }
+}
+

--- a/src/main/java/no/ssb/dapla/team/users/UserServiceException.java
+++ b/src/main/java/no/ssb/dapla/team/users/UserServiceException.java
@@ -1,0 +1,11 @@
+package no.ssb.dapla.team.users;
+
+public class UserServiceException extends RuntimeException {
+    public UserServiceException(String message) {
+        super(message);
+    }
+
+    public UserServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
-management.endpoint.health.probes.enabled=true
-
 app.name=dapla-team-api
 
-management.endpoints.web.exposure.include=health,info,prometheus
+ad.users.exportfile=src/test/resources/ssb-users.csv
 
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.health.probes.enabled=true
 

--- a/src/test/java/no/ssb/dapla/team/users/FilebasedUserServiceTest.java
+++ b/src/test/java/no/ssb/dapla/team/users/FilebasedUserServiceTest.java
@@ -1,0 +1,18 @@
+package no.ssb.dapla.team.users;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilebasedUserServiceTest {
+
+    @Test
+    void fetchAllUsers() {
+        FilebasedUserService userService = new FilebasedUserService("src/test/resources/ssb-users.csv");
+        List<User> users = userService.fetchAllUsers();
+        assertThat(users).isNotEmpty();
+        assertThat(users.get(0).getName()).isEqualTo("Ku Klara");
+    }
+}

--- a/src/test/resources/ssb-users.csv
+++ b/src/test/resources/ssb-users.csv
@@ -1,3 +1,4 @@
+userPrincipalName,displayName,mail
 klk@ssb.no,Ku Klara,Klara.Ku@ssb.no
 kons-don@ssb.no,Duck Donald,Donald.Duck@ssb.no
 kons-orn@ssb.no,Ørnulf Ørn,Ornulf.Orn@ssb.no


### PR DESCRIPTION
Introduces a service that can reads users from a CSV file.

The location of the csv file is read from application.properties.

In staging, the CSV file is mounted into the pod's file system as a VolumeMount, like so:
https://github.com/statisticsnorway/platform-dev/blob/master/flux/staging-bip-app/dapla/dapla-team-api/dapla-team-api.yaml#L80-L88

The users file is produced as described here:
https://github.com/statisticsnorway/dapla-start-toolkit#update-ssb-users-list-served-by-dapla-start-api
