### PR TITLE
Collect dapla teams from github api with hub4j/github-api

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -5,6 +5,6 @@ ad.users.exportfile=src/test/resources/ssb-users.csv
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.probes.enabled=true
 
-github.id=239411
+github.id=0
 github.organization=statisticsnorway
-github.privatekey=/Users/anders/work/ssb/githuptestapp/pk/dapla-team-api.2022-09-19.private-key.der
+github.privatekey=/path/to/key

--- a/config/application.properties
+++ b/config/application.properties
@@ -4,3 +4,7 @@ ad.users.exportfile=src/test/resources/ssb-users.csv
 
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.probes.enabled=true
+
+app.id=239411
+app.organization=rubberduck-labs
+github.pk.path=/Users/anders/work/ssb/githuptestapp/pk/dapla-team-api.2022-09-19.private-key.der

--- a/config/application.properties
+++ b/config/application.properties
@@ -5,6 +5,6 @@ ad.users.exportfile=src/test/resources/ssb-users.csv
 management.endpoints.web.exposure.include=health,info,prometheus
 management.endpoint.health.probes.enabled=true
 
-app.id=239411
-app.organization=rubberduck-labs
-github.pk.path=/Users/anders/work/ssb/githuptestapp/pk/dapla-team-api.2022-09-19.private-key.der
+github.id=239411
+github.organization=statisticsnorway
+github.privatekey=/Users/anders/work/ssb/githuptestapp/pk/dapla-team-api.2022-09-19.private-key.der

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
-			<artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if Gson is preferred -->
+			<artifactId>jjwt-jackson</artifactId>
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,28 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.kohsuke</groupId>
+			<artifactId>github-api</artifactId>
+			<version>1.308</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId> <!-- or jjwt-gson if Gson is preferred -->
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/no/ssb/dapla/team/LoadDatabase.java
+++ b/src/main/java/no/ssb/dapla/team/LoadDatabase.java
@@ -12,6 +12,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.IOException;
 import java.util.List;
 
 @Configuration
@@ -28,7 +29,11 @@ public class LoadDatabase {
             // Teams
             //teamRepository.save(teamWithGroupsAndMembers("demo-enhjoern-a", "Demo Enhjørning A", users.subList(0, 5)));
             //teamRepository.save(teamWithGroupsAndMembers("demo-enhjoern-b", "Demo Enhjørning B", users.subList(5, 10)));
-            teamRepository.saveAll(gitHubService.getRepositoryInOrganizationWithTopic("dapla-team"));
+            try {
+                teamRepository.saveAll(gitHubService.getRepositoryInOrganizationWithTopic("dapla-team"));
+            }catch (Exception e){
+                new RuntimeException("Could not load teams with github service");
+            }
         };
     }
 

--- a/src/main/java/no/ssb/dapla/team/LoadDatabase.java
+++ b/src/main/java/no/ssb/dapla/team/LoadDatabase.java
@@ -1,6 +1,7 @@
 package no.ssb.dapla.team;
 
 import lombok.extern.slf4j.Slf4j;
+import no.ssb.dapla.team.github.GitHubService;
 import no.ssb.dapla.team.groups.Group;
 import no.ssb.dapla.team.teams.Team;
 import no.ssb.dapla.team.teams.TeamRepository;
@@ -17,7 +18,7 @@ import java.util.List;
 @Slf4j
 public class LoadDatabase {
     @Bean
-    CommandLineRunner initDatabase(UserRepository userRepository, TeamRepository teamRepository, FilebasedUserService filebasedUserService) {
+    CommandLineRunner initDatabase(UserRepository userRepository, TeamRepository teamRepository, FilebasedUserService filebasedUserService, GitHubService gitHubService) {
 
         return args -> {
             // Users
@@ -25,8 +26,9 @@ public class LoadDatabase {
             userRepository.saveAll(users);
 
             // Teams
-            teamRepository.save(teamWithGroupsAndMembers("demo-enhjoern-a", "Demo Enhjørning A", users.subList(0, 5)));
-            teamRepository.save(teamWithGroupsAndMembers("demo-enhjoern-b", "Demo Enhjørning B", users.subList(5, 10)));
+            //teamRepository.save(teamWithGroupsAndMembers("demo-enhjoern-a", "Demo Enhjørning A", users.subList(0, 5)));
+            //teamRepository.save(teamWithGroupsAndMembers("demo-enhjoern-b", "Demo Enhjørning B", users.subList(5, 10)));
+            teamRepository.saveAll(gitHubService.getRepositoryInOrganizationWithTopic("dapla-team"));
         };
     }
 

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -100,7 +100,6 @@ public class GitHubService {
         return repositoryList;
     }
 
-
     public List<GHRepository> getRepositoryInOrganizationWithNameContaining(String containing) {
         updateTokenIfExpired();
         List<GHRepository> repositoryList;

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -1,0 +1,149 @@
+package no.ssb.dapla.team.github;
+
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.NonNull;
+import no.ssb.dapla.team.teams.Team;
+import org.kohsuke.github.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+@Service
+public class GitHubService {
+    private final long jwtExpirationTimeInMS = 1000;
+
+    private final String appId;
+
+    private final String privateKeyPath;
+
+    private final String organizationName;
+
+    private GHOrganization ghOrganization;
+    private GHAppInstallationToken ghAppInstallationToken;
+
+
+    public GitHubService(@NonNull @Value("${app.id}") String appId,
+                         @NonNull @Value("${github.pk.path}") String privateKeyPath,
+                         @NonNull @Value("${app.organization}") String organizationName) {
+
+        this.organizationName = organizationName;
+        this.appId = appId;
+        this.privateKeyPath = privateKeyPath;
+
+        try {
+            String jwtToken = this.createJWT(appId, privateKeyPath);
+            GitHub gitHubApp = new GitHubBuilder().withJwtToken(jwtToken).build();
+
+
+            GHAppInstallation appInstallation = gitHubApp.getApp().getInstallationByOrganization(organizationName);
+            ghAppInstallationToken = appInstallation.createToken().create();
+            GitHub githubAuthAsInst = new GitHubBuilder().withAppInstallationToken(ghAppInstallationToken.getToken()).build();
+            ghOrganization = githubAuthAsInst.getOrganization(organizationName);
+
+        } catch (Exception e) {
+            new RuntimeException("Could not setup GitHubService");
+        }
+
+    }
+
+    private void updateTokenIfExpired() {
+        try {
+            if (ghAppInstallationToken.getExpiresAt().before(new Date())) {
+
+                String jwtToken = this.createJWT(appId, privateKeyPath); //sdk-github-api-app-test
+                GitHub gitHubApp = new GitHubBuilder().withJwtToken(jwtToken).build();
+
+
+                GHAppInstallation appInstallation = gitHubApp.getApp().getInstallationByOrganization(organizationName);
+                ghAppInstallationToken = appInstallation.createToken().create();
+                GitHub githubAuthAsInst = new GitHubBuilder().withAppInstallationToken(ghAppInstallationToken.getToken()).build();
+                ghOrganization = githubAuthAsInst.getOrganization(organizationName);
+            }
+
+        } catch (Exception e) {
+            new RuntimeException("Could not refresh token");
+        }
+    }
+
+    public List<Team> getRepositoryInOrganizationWithTopic(String topic) {
+        updateTokenIfExpired();
+        LinkedList<Team> repositoryList = new LinkedList<>();
+        try {
+            for (GHRepository ghRepository : ghOrganization.getRepositories().values()) {
+                for (String tempTopic : ghRepository.listTopics()) {
+                    if (tempTopic.equals(topic)) {
+                        repositoryList.add(Team.builder().
+                                uniformTeamName(ghRepository.getName())
+                                .uniformTeamName(ghRepository.getName().replace("-", " "))
+                                .build());
+                        break;
+                    }
+
+                }
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to get organizations repositories containing: " + topic);
+        }
+        return repositoryList;
+    }
+
+
+    public List<GHRepository> getRepositoryInOrganizationWithNameContaining(String containing) {
+        updateTokenIfExpired();
+        List<GHRepository> repositoryList;
+        try {
+
+            repositoryList = ghOrganization.getRepositories()
+                    .values()
+                    .stream()
+                    .filter(ghRepository -> ghRepository.getName().contains(containing)).toList();
+
+
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to get organizations repositories containing: " + containing);
+        }
+        return repositoryList;
+    }
+
+    private PrivateKey getPrivateKey(String filename) throws Exception {
+        byte[] keyBytes = Files.readAllBytes(Paths.get(filename));
+
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        return kf.generatePrivate(spec);
+    }
+
+    private String createJWT(String githubAppId, String path) throws Exception {
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.RS256;
+
+        long nowMillis = System.currentTimeMillis();
+        Date now = new Date(nowMillis);
+
+        //Sign JWT with private key
+        Key signingKey = getPrivateKey(path);
+
+        //Set the JWT Claims
+        JwtBuilder builder = Jwts.builder().setIssuedAt(now).setIssuer(githubAppId).signWith(signingKey, signatureAlgorithm);
+
+        //Add the expiration
+        long expMillis = nowMillis + jwtExpirationTimeInMS;
+        Date exp = new Date(expMillis);
+        builder.setExpiration(exp);
+
+        return builder.compact();
+    }
+
+}

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -76,10 +76,9 @@ public class GitHubService {
         }
     }
 
-    public List<Team> getRepositoryInOrganizationWithTopic(String topic) {
+    public List<Team> getRepositoryInOrganizationWithTopic(String topic) throws Exception {
         updateTokenIfExpired();
         LinkedList<Team> repositoryList = new LinkedList<>();
-        try {
             for (GHRepository ghRepository : ghOrganization.getRepositories().values()) {
                 for (String tempTopic : ghRepository.listTopics()) {
                     if (tempTopic.equals(topic)) {
@@ -93,9 +92,6 @@ public class GitHubService {
                 }
             }
 
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to get organizations repositories containing: " + topic);
-        }
         return repositoryList;
     }
 

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -45,8 +45,7 @@ public class GitHubService {
         try {
             String jwtToken = this.createJWT(appId, privateKeyPath);
             GitHub gitHubApp = new GitHubBuilder().withJwtToken(jwtToken).build();
-
-
+            
             GHAppInstallation appInstallation = gitHubApp.getApp().getInstallationByOrganization(organizationName);
             ghAppInstallationToken = appInstallation.createToken().create();
             GitHub githubAuthAsInst = new GitHubBuilder().withAppInstallationToken(ghAppInstallationToken.getToken()).build();

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -107,7 +107,8 @@ public class GitHubService {
             repositoryList = ghOrganization.getRepositories()
                     .values()
                     .stream()
-                    .filter(ghRepository -> ghRepository.getName().contains(containing)).toList();
+                    .filter(ghRepository -> ghRepository.getName().contains(containing))
+                    .toList();
 
 
         } catch (IOException e) {

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -61,7 +61,7 @@ public class GitHubService {
         try {
             if (ghAppInstallationToken.getExpiresAt().before(new Date())) {
 
-                String jwtToken = this.createJWT(appId, privateKeyPath); //sdk-github-api-app-test
+                String jwtToken = this.createJWT(appId, privateKeyPath);
                 GitHub gitHubApp = new GitHubBuilder().withJwtToken(jwtToken).build();
 
 

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -34,9 +34,9 @@ public class GitHubService {
     private GHAppInstallationToken ghAppInstallationToken;
 
 
-    public GitHubService(@NonNull @Value("${app.id}") String appId,
-                         @NonNull @Value("${github.pk.path}") String privateKeyPath,
-                         @NonNull @Value("${app.organization}") String organizationName) {
+    public GitHubService(@NonNull @Value("${github.id}") String appId,
+                         @NonNull @Value("${github.privatekey}") String privateKeyPath,
+                         @NonNull @Value("${github.organization}") String organizationName) {
 
         this.organizationName = organizationName;
         this.appId = appId;
@@ -45,7 +45,7 @@ public class GitHubService {
         try {
             String jwtToken = this.createJWT(appId, privateKeyPath);
             GitHub gitHubApp = new GitHubBuilder().withJwtToken(jwtToken).build();
-            
+
             GHAppInstallation appInstallation = gitHubApp.getApp().getInstallationByOrganization(organizationName);
             ghAppInstallationToken = appInstallation.createToken().create();
             GitHub githubAuthAsInst = new GitHubBuilder().withAppInstallationToken(ghAppInstallationToken.getToken()).build();

--- a/src/main/java/no/ssb/dapla/team/github/GitHubService.java
+++ b/src/main/java/no/ssb/dapla/team/github/GitHubService.java
@@ -86,7 +86,7 @@ public class GitHubService {
                     if (tempTopic.equals(topic)) {
                         repositoryList.add(Team.builder().
                                 uniformTeamName(ghRepository.getName())
-                                .uniformTeamName(ghRepository.getName().replace("-", " "))
+                                .displayTeamName(ghRepository.getName().replace("-", " "))
                                 .build());
                         break;
                     }


### PR DESCRIPTION
Add a GitHubService that uses the hub4j/github-api library to access the organization trough a GitHub app.
The service adds teams to the database during loading.

For more info about github apps see: https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps