### PR TITLE
Add swagger docs

### DIFF
--- a/config/application.properties
+++ b/config/application.properties
@@ -13,3 +13,5 @@ ad.app.client.id=12345678-ba44-4b12-9cb5-3c625844d1a4
 ad.app.tenant.id=12345678-bcc4-45b5-94a4-c06e686b75ad
 ad.app.certificate.file=/path/to/azure-app-certificate.pfx
 ad.app.certificate.password=dummypassword
+
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.0-M4</version>
+        <version>2.7.4</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>no.ssb.dapla</groupId>
@@ -122,6 +122,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.1.26</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/no/ssb/dapla/team/groups/Group.java
+++ b/src/main/java/no/ssb/dapla/team/groups/Group.java
@@ -1,9 +1,9 @@
 package no.ssb.dapla.team.groups;
 
-import jakarta.persistence.*;
 import lombok.*;
 import no.ssb.dapla.team.users.User;
 
+import javax.persistence.*;
 import java.util.List;
 
 @Getter

--- a/src/main/java/no/ssb/dapla/team/teams/Team.java
+++ b/src/main/java/no/ssb/dapla/team/teams/Team.java
@@ -1,9 +1,9 @@
 package no.ssb.dapla.team.teams;
 
-import jakarta.persistence.*;
 import lombok.*;
 import no.ssb.dapla.team.groups.Group;
 
+import javax.persistence.*;
 import java.util.List;
 
 @Getter

--- a/src/main/java/no/ssb/dapla/team/users/User.java
+++ b/src/main/java/no/ssb/dapla/team/users/User.java
@@ -1,9 +1,10 @@
 package no.ssb.dapla.team.users;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import lombok.*;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
 
 @Getter
 @Setter


### PR DESCRIPTION
Switch spring version to 2.7.4 because of lacking support for springdoc-openapi.

Had to swap out jakarta.persistence with javax.persistence.

Added a matching strategy to application.properties, for more info see:
https://spring.io/blog/2020/06/30/url-matching-with-pathpattern-in-spring-mvc